### PR TITLE
refactor(devct): use 0.2.2 with k3d

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "workflows-training",
-	"image": "quay.io/akuity/argo-cd-learning-assets/akuity-devcontainer:0.2.1",
+	"image": "quay.io/akuity/argo-cd-learning-assets/akuity-devcontainer:0.2.2",
 
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,7 +4,6 @@
 echo "post-create start" >> ~/.status.log
 
 ## Create k3s cluster
-wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 k3d cluster create --config .devcontainer/k3d.yaml --wait | tee -a ~/.status.log
 
 ## Install


### PR DESCRIPTION
`akuity-devcontainer:0.2.2` comes with `k3d` now (added in https://github.com/akuity/argo-cd-learning-assets/pull/5). Remove install in `post-create` script.